### PR TITLE
Bug Fix - Empty Divs

### DIFF
--- a/HardDiff.html
+++ b/HardDiff.html
@@ -8,10 +8,6 @@
 
 <body>
   <h1> Hard Difficulty </h1>
-  
-  <div>
-
-  </div>
   <footer>
     <p class= "Zapfino"> Developed by Michael Zenkis </p>
   </footer>

--- a/MediumDiff.html
+++ b/MediumDiff.html
@@ -8,9 +8,6 @@
 
 <body>
   <h1> Medium Difficulty </h1>
-  <div>
-
-  </div>
   <footer>
     <p class= "Zapfino"> Developed by Michael Zenkis </p>
   </footer>


### PR DESCRIPTION
The divs were empty and not used.
That is why the "Trimming empty" warning was being raised.

This resolves issue #3 

Please review and merge if you are happy. If you got any questions, comment below.
